### PR TITLE
Gitignore the built beacon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ _testmain.go
 *.prof
 
 certificates
+
+beacon


### PR DESCRIPTION
Just a quick gitignore of `./beacon` for the go build.
